### PR TITLE
Add support for pause / start messages

### DIFF
--- a/src/aws-ssm-session.ts
+++ b/src/aws-ssm-session.ts
@@ -28,7 +28,7 @@ export default class AWSSSMSession {
 		this.sessionId = sessionId;
 		this.webSocket = new WebSocket(this.streamUrl);
 		this.webSocket.binaryType = 'arraybuffer';
-		this.webSocket.onopen = (ev: Event) => {
+		this.webSocket.onopen = (ev: WebSocket.OpenEvent) => {
 			this.webSocket.send(
 				JSON.stringify({
 					MessageSchemaVersion: '1.0',
@@ -55,9 +55,6 @@ export default class AWSSSMSession {
 					break
 				}
 				case 'start_publication': {
-					if ( this.paused === false ) {
-						console.log( 'Session recieved start_publication message when the connection was not paused.' );
-					}
 					if ( this.lastAcknowledgedSequenceNumber !== undefined ) {
 						this.outgoingSequenceNumber = this.lastAcknowledgedSequenceNumber;
 					} else {
@@ -70,7 +67,6 @@ export default class AWSSSMSession {
 				case 'pause_publication': {
 					this.paused = true;
 					this.emit( 'pause', '' );
-					console.warn( 'Recieved pause_publication message, all sent messages may be discarded until start_publication is recieved.' );
 					break;
 				}
 				case 'acknowledge': {

--- a/src/aws-ssm-session.ts
+++ b/src/aws-ssm-session.ts
@@ -14,10 +14,19 @@ export default class AWSSSMSession {
 	sessionId: string;
 	tokenValue: string;
 	streamUrl: string;
+	// Each message that is sent to the SSM websocket is assigned a sequenceNumber
+	// so the receiver can verify it has not missed any messages (sequenceNumber is
+	// an incrementing integer). Also, messages can be ordered back into sequence if
+	// anything were to get ahead of line.
 	outgoingSequenceNumber = 0;
 	outputMap = new Map();
 	connectionClosed = false;
 	connectionTerminated = false;
+	// Each message that is sent with a sequenceNumber is replied to with an
+	// acknowledgement from the SSM remote agent. We keep track of the latest
+	// sequenceNumber that has been acknowledged, so we know what number to reset
+	// to if we fall out of sync with the remove server. Currently no buffering or
+	// replaying of messages exists, but it could be added in the future.
 	lastAcknowledgedSequenceNumber: number | undefined;
 	handlers: Handler[] = [];
 	paused: boolean = false;


### PR DESCRIPTION
When pause messages are received, we fall out of sync with the `outgoingSequenceNumber` as we send messages that are never acknowledged. This could also happen before the websocket is ready, so I added a check for that.
